### PR TITLE
added plt.close() in loop making plots

### DIFF
--- a/pyemu/plot/plot_utils.py
+++ b/pyemu/plot/plot_utils.py
@@ -1273,7 +1273,8 @@ def plot_jac_test(csvin, csvout, targetobs=None, filetype=None, maxoutputpages=1
     num_obs_plotted = np.min(np.array([maxoutputpages*32, len(targetobs)]))
     if num_obs_plotted < len(targetobs):
         # get random sample
-        obs_plotted = np.random.choice(len(targetobs), num_obs_plotted, replace=False)
+        index_plotted = np.random.choice(len(targetobs), num_obs_plotted, replace=False)
+        obs_plotted = [targetobs[x] for x in index_plotted]
         real_pages = maxoutputpages
     else:
         obs_plotted = targetobs
@@ -1287,7 +1288,7 @@ def plot_jac_test(csvin, csvout, targetobs=None, filetype=None, maxoutputpages=1
             for row in range(0, 8):
                 for col in range(0, 4):
                     count = 32 * page + 4 * row + col
-                    if count < len(targetobs):
+                    if count < num_obs_plotted:
                         axes[row, col].scatter(group['increment'], group[obs_plotted[count]])
                         axes[row, col].plot(group['increment'], group[obs_plotted[count]], 'r')
                         axes[row, col].set_title(obs_plotted[count])
@@ -1301,3 +1302,4 @@ def plot_jac_test(csvin, csvout, targetobs=None, filetype=None, maxoutputpages=1
                 plt.show()
             else:
                 plt.savefig(os.path.join(figures_dir, "{0}_jactest_{1}.{2}".format(param, page, filetype)))
+            plt.close()


### PR DESCRIPTION
Without the explicit plt.close() the plots were not being closed and taking a lot of memory when there were a larger number of parameters to plot.