### PR TITLE
Some ensemble plotting changes (support df input, deal with "unnamed" cols during csv read)

### DIFF
--- a/pyemu/plot/plot_utils.py
+++ b/pyemu/plot/plot_utils.py
@@ -1131,11 +1131,15 @@ def ensemble_change_summary(ensemble1, ensemble2, pst,bins=10, facecolor='0.5',l
 
     if isinstance(ensemble1, str):
         ensemble1 = pd.read_csv(ensemble1,index_col=0)
-        ensemble1.columns = ensemble1.columns.str.lower()
+    ensemble1.columns = ensemble1.columns.str.lower()
 
     if isinstance(ensemble2, str):
         ensemble2 = pd.read_csv(ensemble2,index_col=0)
-        ensemble2.columns = ensemble2.columns.str.lower()
+    ensemble2.columns = ensemble2.columns.str.lower()
+
+    # assuming that unnamed cols will occur as result of csv read only - better to fix in pestpp-ies
+    ensemble1.drop([col for col in ensemble1.columns if "unnamed:" in col],axis=1,inplace=True)
+    ensemble2.drop([col for col in ensemble2.columns if "unnamed:" in col],axis=1,inplace=True)
 
     d = set(ensemble1.columns).symmetric_difference(set(ensemble2. columns))
 
@@ -1163,7 +1167,7 @@ def ensemble_change_summary(ensemble1, ensemble2, pst,bins=10, facecolor='0.5',l
             grouper = obs.groupby(obs.obgnme).groups
             grouper["all"] = pst.nnz_obs_names
         else:
-            logger.lraise("could match ensemble cols with par or obs...")
+            logger.lraise("could not match ensemble cols with par or obs...")
 
 
     fig = plt.figure(figsize=figsize)

--- a/pyemu/plot/plot_utils.py
+++ b/pyemu/plot/plot_utils.py
@@ -1137,9 +1137,13 @@ def ensemble_change_summary(ensemble1, ensemble2, pst,bins=10, facecolor='0.5',l
         ensemble2 = pd.read_csv(ensemble2,index_col=0)
     ensemble2.columns = ensemble2.columns.str.lower()
 
-    # assuming that unnamed cols will occur as result of csv read only - better to fix in pestpp-ies
-    ensemble1.drop([col for col in ensemble1.columns if "unnamed:" in col],axis=1,inplace=True)
-    ensemble2.drop([col for col in ensemble2.columns if "unnamed:" in col],axis=1,inplace=True)
+    # better to ensure this is caught by pestpp-ies ensemble csvs
+    unnamed1 = [col for col in ensemble1.columns if "unnamed:" in col]
+    if len(unnamed1) != 0:
+        ensemble1 = ensemble1.iloc[:,:-1] # ensure unnamed col result of poor csv read only (ie last col)
+    unnamed2 = [col for col in ensemble2.columns if "unnamed:" in col]
+    if len(unnamed2) != 0:
+        ensemble2 = ensemble2.iloc[:,:-1] # ensure unnamed col result of poor csv read only (ie last col)
 
     d = set(ensemble1.columns).symmetric_difference(set(ensemble2. columns))
 


### PR DESCRIPTION
Changes to support ensemble plotting from dfs as well as csv paths, and address unnamed cols added to df when reading ensemble csv files following pestpp-ies. The latter issue should be caught by the most recent build of pestpp-ies.