### PR TITLE
Modifying load_sfr_out() to only aggregate flaqx.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ pyEMU
 
 python modules for model-independent FOSM (first-order, second-moment) (a.k.a linear-based, a.k.a. Bayes linear) uncertainty analyses and data-worth analyses, non-linear uncertainty analyses and interfacing with PEST and PEST++.  pyEMU now also has a pure python (pandas and numpy) implementation of ordinary kriging for geostatistical interpolation.   
 
-[![Travis Status](https://travis-ci.org/jtwhite79/pyemu.svg?branch=develop)](https://travis-ci.org/jtwhite79/pyemu)
-[![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/jtwhite79/pyemu?branch=develop&svg=true)](https://ci.appveyor.com/project/jtwhite79/pyemu)
+[![Travis Status](https://travis-ci.org/jtwhite79/pyemu.svg?branch=master)](https://travis-ci.org/jtwhite79/pyemu)
+[![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/jtwhite79/pyemu?branch=master&svg=true)](https://ci.appveyor.com/project/jtwhite79/pyemu)
 [![Coverage Status](https://coveralls.io/repos/github/jtwhite79/pyemu/badge.svg?branch=develop)](https://coveralls.io/github/jtwhite79/pyemu?branch=develop)
 
 Read the docs

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1272,8 +1272,8 @@ def sfr_obs_test():
 
     m = flopy.modflow.Modflow.load("freyberg.nam",model_ws="utils",load_only=[],check=False)
     pyemu.gw_utils.setup_sfr_obs(sfr_file,model=m)
+    pyemu.gw_utils.apply_sfr_obs()
     pyemu.gw_utils.setup_sfr_obs(sfr_file, seg_group_dict={"obs1": [1, 4], "obs2": [16, 17, 18, 19, 22, 23]},model=m)
-
 
 def gage_obs_test():
     import os
@@ -1475,16 +1475,16 @@ def smp_dateparser_test():
 
 
 if __name__ == "__main__":
-    smp_test()
-    smp_dateparser_test()
-    smp_to_ins_test()
+    # smp_test()
+    # smp_dateparser_test()
+    # smp_to_ins_test()
     #read_runstor_test()
     #long_names()
     #master_and_slaves()
     #plot_id_bar_test()
     #pst_from_parnames_obsnames_test()
     #write_jactest_test()
-    #sfr_obs_test()
+    sfr_obs_test()
     #gage_obs_test()
     #setup_pp_test()
     #sfr_helper_test()


### PR DESCRIPTION
Modifying load_sfr_out() to only aggregate flaqx.

We have been aggregating flow out in the whole seg when setting up and applying sfr_obs. 
This has just caught me out and I dont think it really makes sense this output type.

Modifying so flout is now taken as the flow at the downstream end of the segment (at max
reach number for segment). flaqx is still aggregated for whole segment. 

TODO: generalise setting up obs on seg,reach combinations.