### PR TITLE
Correcting some messyness with specifying sfr_pars in ph setup

### DIFF
--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -713,8 +713,8 @@ def from_flopy_reachinput():
                                                  model_exe_name="mfnwt", sfr_pars=sfr_par, sfr_obs=True)
         os.chdir(new_model_ws)
         mult_files = []
+        spars = {}
         try:  # read seg pars config file
-            spars = {}
             with open("sfr_seg_pars.config", 'r') as f:
                 for line in f:
                     line = line.strip().split()
@@ -725,8 +725,8 @@ def from_flopy_reachinput():
                 pass
             else:
                 raise Exception()
+        rpars = {}
         try:  # read reach pars config file
-            rpars = {}
             with open("sfr_reach_pars.config", 'r') as f:
                 for line in f:
                     line = line.strip().split()
@@ -741,16 +741,9 @@ def from_flopy_reachinput():
             # actually write out files to check template file
             helper.pst.write_input_files()
             try:
-                pyemu.gw_utils.apply_sfr_parameters(reach_pars=True)
+                exec(helper.frun_pre_lines[0])
             except Exception as e:
-                if i == 2:
-                    pass
-                    try:
-                        pyemu.gw_utils.apply_sfr_parameters(reach_pars=False)
-                    except Exception as e:
-                        raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
-                else:
-                    raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
+                raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
 
             # test using tempchek for writing tpl file
             par = helper.pst.parameter_data
@@ -771,20 +764,9 @@ def from_flopy_reachinput():
                         raise Exception("error running tempchek on template file {0} and data file {1} : {0}".
                                         format(mult, "{}.tpl".format(tpl_file), str(e)))
                 try:
-                    pyemu.gw_utils.apply_sfr_parameters(reach_pars=True)
+                    exec(helper.frun_pre_lines[0])
                 except Exception as e:
-                    if i == 2:
-                        pass
-                        try:
-                            pyemu.gw_utils.apply_sfr_parameters(reach_pars=False)
-                        except Exception as e:
-                            raise Exception(
-                                "error applying sfr pars with tempchek par file, check tpl(s) and datafiles: {0}".
-                                    format(str(e)))
-                    else:
-                        raise Exception(
-                            "error applying sfr pars with tempchek par file, check tpl(s) and datafiles: {0}".
-                                format(str(e)))
+                    raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
         except:
             if i == 3:  # scenario 3 should not set up any parameters
                 pass
@@ -1187,11 +1169,11 @@ if __name__ == "__main__":
     # add_pars_test()
     # setattr_test()
     # run_array_pars()
-    from_flopy_zone_pars()
+    # from_flopy_zone_pars()
     #from_flopy()
     # add_obs_test()
     #from_flopy_kl_test()
-    #from_flopy_test_reachinput_test()
+    from_flopy_test_reachinput_test()
     # add_pi_test()
     # regdata_test()
     # nnz_groups_test()
@@ -1208,7 +1190,7 @@ if __name__ == "__main__":
     # test_e_clean()
     # load_test()
     # flex_load_test()
-    res_test()
+    # res_test()
     # smp_test()
     # from_io_with_inschek_test()
     # pestpp_args_test()

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -1703,6 +1703,8 @@ class PstFromFlopyModel(object):
         self.setup_array_pars()
 
         if sfr_pars:
+            if isinstance(sfr_pars, str):
+                sfr_pars = [sfr_pars]
             if isinstance(sfr_pars, list):
                 self.setup_sfr_pars(sfr_pars)
             else:
@@ -1767,12 +1769,14 @@ class PstFromFlopyModel(object):
         if isinstance(par_cols, str):
             par_cols = [par_cols]
         reach_pars = False # default to False
+        seg_pars = True
         par_dfs = {}
         df = pyemu.gw_utils.setup_sfr_seg_parameters(self.m, par_cols=par_cols)  # now just pass model
         # self.par_dfs["sfr"] = df
         if df.empty:
             warnings.warn("No sfr segment parameters have been set up", PyemuWarning)
             par_dfs["sfr"] = []
+            seg_pars = False
         else:
             par_dfs["sfr"] = [df]  # may need df for both segs and reaches
             self.tpl_files.append("sfr_seg_pars.dat.tpl")
@@ -1785,9 +1789,11 @@ class PstFromFlopyModel(object):
                 self.tpl_files.append("sfr_reach_pars.dat.tpl")
                 self.in_files.append("sfr_reach_pars.dat")
                 reach_pars = True
+                par_dfs["sfr"].append(df)
         if len(par_dfs["sfr"]) > 0:
             self.par_dfs["sfr"] = pd.concat(par_dfs["sfr"])
-            self.frun_pre_lines.append("pyemu.gw_utils.apply_sfr_parameters(reach_pars={0})".format(reach_pars))
+            self.frun_pre_lines.append(
+                "pyemu.gw_utils.apply_sfr_parameters(seg_pars={0}, reach_pars={1})".format(seg_pars, reach_pars))
         else:
             warnings.warn("No sfr parameters have been set up!", PyemuWarning)
 


### PR DESCRIPTION
Previous behaviour was trying to setup segment pars even if only
paramters in reach_data were requested in
`pyemu.helpers.PstFromFlopyModel(sfr_pars=["pars"])`. Also the par setup
wasn't finalising if only reach_data pars were setup, the
`apply_sfr_pars()` line was being ommited from frun file. I think the blame soley rests with me for that one!