### PR TITLE
Adding fixes to cov build methods to deal with tied and fixed pars.

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -740,7 +740,7 @@ def geostat_prior_builder_test():
     import pyemu
     pst_file = os.path.join("pst","pest.pst")
     pst = pyemu.Pst(pst_file)
-
+    # print(pst.parameter_data)
     tpl_file = os.path.join("utils", "pp_locs.tpl")
     str_file = os.path.join("utils", "structure.dat")
 
@@ -755,9 +755,17 @@ def geostat_prior_builder_test():
     cov = pyemu.helpers.geostatistical_prior_builder(pst_file,{gs:df},
                                                sigma_range=4)
     nnz = np.count_nonzero(cov.x)
-    assert nnz == pst.npar
+    assert nnz == pst.npar_adj
     d2 = np.diag(cov.x)
     assert np.array_equiv(d1, d2)
+
+    pst.parameter_data.loc[pst.par_names[1:10], "partrans"] = "tied"
+    pst.parameter_data.loc[pst.par_names[1:10], "partied"] = pst.par_names[0]
+    cov = pyemu.helpers.geostatistical_prior_builder(pst, {gs: df},
+                                                     sigma_range=4)
+    nnz = np.count_nonzero(cov.x)
+    assert nnz == pst.npar_adj
+
 
     ttpl_file = os.path.join("temp", "temp.dat.tpl")
     with open(ttpl_file, 'w') as f:
@@ -768,7 +776,7 @@ def geostat_prior_builder_test():
     pst.parameter_data.loc["temp1", "parlbnd"] = 0.9
 
     cov = pyemu.helpers.geostatistical_prior_builder(pst, {str_file: tpl_file})
-    assert cov.shape[0] == 602
+    assert cov.shape[0] == pst.npar_adj
 
     scov = pyemu.helpers.sparse_geostatistical_prior_builder(pst,{str_file: tpl_file}).to_matrix()
     d = (cov - scov).x
@@ -1586,8 +1594,8 @@ if __name__ == "__main__":
     # gslib_2_dataframe_test()
     # sgems_to_geostruct_test()
     # #linearuniversal_krige_test()
-    # geostat_prior_builder_test()
-    geostat_draws_test()
+    geostat_prior_builder_test()
+    # geostat_draws_test()
     #jco_from_pestpp_runstorage_test()
     # mflist_budget_test()
     # mtlist_budget_test()

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -380,8 +380,14 @@ def sparse_geostatistical_prior_builder(pst, struct_dict,sigma_range=4,verbose=F
             if "zone" not in df.columns:
                 df.loc[:,"zone"] = 1
             zones = df.zone.unique()
+            aset = set(pst.adj_par_names)
             for zone in zones:
                 df_zone = df.loc[df.zone==zone,:].copy()
+                df_zone = df_zone.loc[df_zone.parnme.apply(lambda x: x in aset), :]
+                if df_zone.shape[0] == 0:
+                    warnings.warn("all parameters in zone {0} tied and/or fixed, skipping...".format(zone),
+                                  PyemuWarning)
+                    continue
                 df_zone.sort_values(by="parnme",inplace=True)
                 if verbose: print("build cov matrix")
                 cov = gs.sparse_covariance_matrix(df_zone.x,df_zone.y,df_zone.parnme)
@@ -403,7 +409,7 @@ def sparse_geostatistical_prior_builder(pst, struct_dict,sigma_range=4,verbose=F
 
     if verbose: print("adding remaining parameters to diagonal")
     fset = set(full_cov.row_names)
-    pset = set(pst.par_names)
+    pset = set(pst.adj_par_names)
     diff = list(pset.difference(fset))
     diff.sort()
     vals = np.array([full_cov_dict[d] for d in diff])
@@ -505,8 +511,14 @@ def geostatistical_prior_builder(pst, struct_dict,sigma_range=4,
             if "zone" not in df.columns:
                 df.loc[:,"zone"] = 1
             zones = df.zone.unique()
+            aset = set(pst.adj_par_names)
             for zone in zones:
                 df_zone = df.loc[df.zone==zone,:].copy()
+                df_zone = df_zone.loc[df_zone.parnme.apply(lambda x: x in aset), :]
+                if df_zone.shape[0] == 0:
+                    warnings.warn("all parameters in zone {0} tied and/or fixed, skipping...".format(zone),
+                                  PyemuWarning)
+                    continue
                 df_zone.sort_values(by="parnme",inplace=True)
                 if verbose: print("build cov matrix")
                 cov = gs.covariance_matrix(df_zone.x,df_zone.y,df_zone.parnme)


### PR DESCRIPTION
Borrowed a whole load from @jtwhite79's geostat draw mods in previous commit 236afdf00154660ecbf1ba8fcb0a14d904a8210d

+ tests and mods to tests to compare with `pst.npar_adj`