### PR TITLE
Marrying temporal SFR pars with reachinput options and specifying sfr_pars options.

### DIFF
--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -688,10 +688,10 @@ def from_flopy_reachinput():
         return
     import pyemu
 
-    if platform.platform().lower().startswith('win'):
-        tempchek = os.path.join("..", "..", "bin", "win", "tempchek.exe")
-    else:
-        tempchek = None  # os.path.join("..", "..", "bin", "linux", "tempchek")
+    # if platform.platform().lower().startswith('win'):
+    #     tempchek = os.path.join("..", "..", "bin", "win", "tempchek.exe")
+    # else:
+    #     tempchek = None  # os.path.join("..", "..", "bin", "linux", "tempchek")
 
     bd = os.getcwd()
     org_model_ws = os.path.join("..", "examples", "freyberg_sfr_reaches")
@@ -704,14 +704,21 @@ def from_flopy_reachinput():
                     ["strhc1", "flow"],
                     ["flow", "runoff"],
                     ["not_a_par", "not_a_par2"],
-                    "strhc1"]
+                    "strhc1",
+                    ["strhc1", "flow", "runoff"]]
     for i, sfr_par in enumerate(args_to_test):  # if i=2 no reach pars, i==3 no pars, i=4 no seg pars
         for f in ["sfr_reach_pars.config", "sfr_seg_pars.config"]:  # clean up
             if os.path.exists(f):
                 os.remove(f)
+        if i < 5:
+            include_temporal_pars = False
+        else:
+            include_temporal_pars = True
         helper = pyemu.helpers.PstFromFlopyModel(nam_file, new_model_ws, org_model_ws,
                                                  hds_kperk=[0, 0], remove_existing=True,
-                                                 model_exe_name="mfnwt", sfr_pars=sfr_par, sfr_obs=True)
+                                                 model_exe_name="mfnwt", sfr_pars=sfr_par,
+                                                 temporal_sfr_pars=include_temporal_pars,
+                                                 sfr_obs=True)
         os.chdir(new_model_ws)
         mult_files = []
         spars = {}
@@ -747,32 +754,32 @@ def from_flopy_reachinput():
                 raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
 
             # test using tempchek for writing tpl file
-            par = helper.pst.parameter_data
-            if rpars == {}:
-                par_file = "{}.par".format(spars['nam_file'])
-            else:
-                par_file = "{}.par".format(rpars['nam_file'])
-            with open(par_file, 'w') as f:
-                f.write('single point\n')
-                f.flush()
-                par[['parnme', 'parval1', 'scale', 'offset']].to_csv(f, sep=' ', header=False, index=False, mode='a')
-            if tempchek is not None:
-                for mult in mult_files:
-                    tpl_file = "{}.tpl".format(mult)
-                    try:
-                        pyemu.os_utils.run("{} {} {} {}".format(tempchek, tpl_file, mult, par_file))
-                    except Exception as e:
-                        raise Exception("error running tempchek on template file {0} and data file {1} : {0}".
-                                        format(mult, "{}.tpl".format(tpl_file), str(e)))
-                try:
-                    exec(helper.frun_pre_lines[0])
-                except Exception as e:
-                    raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
-        except:
+            # par = helper.pst.parameter_data
+            # if rpars == {}:
+            #     par_file = "{}.par".format(spars['nam_file'])
+            # else:
+            #     par_file = "{}.par".format(rpars['nam_file'])
+            # with open(par_file, 'w') as f:
+            #     f.write('single point\n')
+            #     f.flush()
+            #     par[['parnme', 'parval1', 'scale', 'offset']].to_csv(f, sep=' ', header=False, index=False, mode='a')
+            # if tempchek is not None:
+                # for mult in mult_files:
+                #     tpl_file = "{}.tpl".format(mult)
+                #     try:
+                #         pyemu.os_utils.run("{} {} {} {}".format(tempchek, tpl_file, mult, par_file))
+                #     except Exception as e:
+                #         raise Exception("error running tempchek on template file {1} and data file {0} : {2}".
+                #                         format(mult, tpl_file, str(e)))
+                # try:
+                #     exec(helper.frun_pre_lines[0])
+                # except Exception as e:
+                #     raise Exception("error applying sfr pars, check tpl(s) and datafiles: {0}".format(str(e)))
+        except Exception as e:
             if i == 3:  # scenario 3 should not set up any parameters
                 pass
             else:
-                raise Exception()
+                raise Exception(str(e))
         os.chdir(bd)
 
 

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -1381,10 +1381,10 @@ def setup_sfr_seg_parameters(nam_file, model_ws='.', par_cols=["flow", "runoff",
     if include_temporal_pars:
         # include only stress periods that are explicitly listed in segment data
         pnames,tpl_str = [],[]
-        tmp_df = pd.DataFrame(data={c:1.0 for c in par_cols},index=list(m.sfr.segment_data.keys()))
+        tmp_df = pd.DataFrame(data={c:1.0 for c in cols},index=list(m.sfr.segment_data.keys()))
         tmp_df.sort_index(inplace=True)
         tmp_df.to_csv(os.path.join(model_ws,"sfr_seg_temporal_pars.dat"))
-        for par_col in par_cols:
+        for par_col in cols:
             print(par_col)
             parnme = tmp_df.index.map(lambda x: "{0}_{1:04d}_tmp".format(par_col,int(x)))
             tmp_df.loc[:,par_col] = parnme.map(lambda x: "~   {0}  ~".format(x))
@@ -1416,6 +1416,7 @@ def setup_sfr_seg_parameters(nam_file, model_ws='.', par_cols=["flow", "runoff",
     df.loc[hpars, "parlbnd"] = 0.01
 
     return df
+
 
 def setup_sfr_reach_parameters(nam_file,model_ws='.', par_cols=['strhc1']):
     """Setup multiplier paramters for reach data, when reachinput option is specififed in sfr.
@@ -1662,7 +1663,7 @@ def apply_sfr_seg_parameters(seg_pars=True, reach_pars=False):
     #m.remove_package("sfr")
     if pars is not None and "time_mult_file" in pars:
         time_mult_file = pars["time_mult_file"]
-        time_mlt_df = pd.read_csv(pars["time_mult_file"], delim_whitespace=False, index_col=0)
+        time_mlt_df = pd.read_csv(time_mult_file, delim_whitespace=False, index_col=0)
         for kper, sdata in m.sfr.segment_data.items():
             assert kper in time_mlt_df.index, "gw_utils.apply_sfr_seg_parameters() error: kper " + \
                                               "{0} not in time_mlt_df index".format(kper)

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -1789,7 +1789,7 @@ class PstFromFlopyModel(object):
         assert self.m.sfr is not None, "can't find sfr package..."
         if isinstance(par_cols, str):
             par_cols = [par_cols]
-        reach_pars = False # default to False
+        reach_pars = False  # default to False
         seg_pars = True
         par_dfs = {}
         df = pyemu.gw_utils.setup_sfr_seg_parameters(self.m, par_cols=par_cols,
@@ -1807,8 +1807,8 @@ class PstFromFlopyModel(object):
                 self.tpl_files.append("sfr_seg_temporal_pars.dat.tpl")
                 self.in_files.append("sfr_seg_temporal_pars.dat")
         if self.m.sfr.reachinput:
-            if include_temporal_pars:
-                raise NotImplementedError("temporal pars is not set up for reach data style")
+            # if include_temporal_pars:
+            #     raise NotImplementedError("temporal pars is not set up for reach data style")
             df = pyemu.gw_utils.setup_sfr_reach_parameters(self.m, par_cols=par_cols)
             if df.empty:
                 warnings.warn("No sfr reach parameters have been set up", PyemuWarning)


### PR DESCRIPTION
new temporal sfr pars shouldn't effect setup of reach pars as reach pars
are just in dataset 2 for SFR, tempoal pars should apply to only segdata
(data set 6/4).

So just a minor change to support case where a reach parameter is listed
in sfr_pars (passed to `PstFromFlopyModel()` as `sfr_pars` or
`setup_sfr_pars()` as `par_cols`)

Also added test in `from_flopy_reachinput()` to add
`temporal_sfr_pars=True`.