### PR TITLE
Hfb test and windows `to.csv()` tpl write fix

### DIFF
--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1518,6 +1518,7 @@ def hfb_zn_mult_test():
     for i in range(m.nrow)[21:]:
         hfb_data.append([0, i, jcol1, i, jcol2, 0.003])
     flopy.modflow.ModflowHfb(m, 0, 0, len(hfb_data), hfb_data=hfb_data)
+    orig_len = len(m.hfb6.hfb_data)
     m.change_model_ws("temp")
     m.write_input()
     m.exe_name = "mfnwt"
@@ -1528,7 +1529,7 @@ def hfb_zn_mult_test():
 
     orig_vals, tpl_file = pyemu.gw_utils.write_hfb_zone_multipliers_template(m)
     assert os.path.exists(tpl_file)
-    hfb_pars = pd.read_csv(os.path.join('temp', 'hfb6_pars.csv'))
+    hfb_pars = pd.read_csv(os.path.join(m.model_ws, 'hfb6_pars.csv'))
     hfb_tpl_contents = open(tpl_file, 'r').readlines()
     mult_str = ''.join(hfb_tpl_contents[1:]).replace(
         '~  hbz_0000  ~', '0.1').replace(
@@ -1536,11 +1537,12 @@ def hfb_zn_mult_test():
         '~  hbz_0002  ~', '10.0')
     with open(hfb_pars.mlt_file.values[0], 'w') as mfp:
         mfp.write(mult_str)
-    pyemu.helpers.apply_hfb_pars(os.path.join('temp', 'hfb6_pars.csv'))
+    pyemu.helpers.apply_hfb_pars(os.path.join(m.model_ws, 'hfb6_pars.csv'))
     with open(hfb_pars.mlt_file.values[0], 'r') as mfp:
         for i, line in enumerate(mfp):
             pass
-    assert i-1 == m.hfb6.hfb_data.shape[0]
+    mhfb = flopy.modflow.ModflowHfb.load(hfb_pars.model_file.values[0], m)
+    assert i-1 == orig_len == len(mhfb.hfb_data)
 
 
 def read_runstor_test():

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1500,7 +1500,8 @@ def hfb_zn_mult_test():
 
     org_model_ws = os.path.join("..", "examples", "freyberg_sfr_update")
     nam_file = "freyberg.nam"
-    m = flopy.modflow.Modflow.load(nam_file, model_ws=org_model_ws, check=False)
+    m = flopy.modflow.Modflow.load(
+        nam_file, model_ws=org_model_ws, check=False)
     try:
         pyemu.gw_utils.write_hfb_template(m)
     except:
@@ -1529,12 +1530,17 @@ def hfb_zn_mult_test():
     assert os.path.exists(tpl_file)
     hfb_pars = pd.read_csv(os.path.join('temp', 'hfb6_pars.csv'))
     hfb_tpl_contents = open(tpl_file, 'r').readlines()
-    mult_str = ''.join(hfb_tpl_contents[1:]).replace('~  hbz_0000  ~', '0.1').replace('~  hbz_0001  ~', '1.0').replace(
+    mult_str = ''.join(hfb_tpl_contents[1:]).replace(
+        '~  hbz_0000  ~', '0.1').replace(
+        '~  hbz_0001  ~', '1.0').replace(
         '~  hbz_0002  ~', '10.0')
     with open(hfb_pars.mlt_file.values[0], 'w') as mfp:
         mfp.write(mult_str)
     pyemu.helpers.apply_hfb_pars(os.path.join('temp', 'hfb6_pars.csv'))
-    # assert df.shape[0] == m.hfb6.hfb_data.shape[0]
+    with open(hfb_pars.mlt_file.values[0], 'r') as mfp:
+        for i, line in enumerate(mfp):
+            pass
+    assert i-1 == m.hfb6.hfb_data.shape[0]
 
 
 def read_runstor_test():
@@ -1670,7 +1676,7 @@ if __name__ == "__main__":
     #gage_obs_test()
     #setup_pp_test()
     #sfr_helper_test()
-    gw_sft_ins_test()
+    # gw_sft_ins_test()
     # par_knowledge_test()
     # grid_obs_test()
     # hds_timeseries_test()

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -2318,8 +2318,8 @@ def write_hfb_zone_multipliers_template(m):
     Returns
     -------
         (hfb_mults, tpl_filename) : (dict, str)
-            a dictionary with original unique HFB conductivity values and their corresponding parameter names
-            and the name of the template file
+            a dictionary with original unique HFB conductivity values and their
+            corresponding parameter names and the name of the template file
 
     """
     assert m.hfb6 is not None
@@ -2330,7 +2330,8 @@ def write_hfb_zone_multipliers_template(m):
     if not os.path.exists(os.path.join(m.model_ws, 'hfb6_org')):
         os.mkdir(os.path.join(m.model_ws, 'hfb6_org'))
     # copy down the original file
-    shutil.copy2(os.path.join(m.model_ws, m.hfb6.file_name[0]), os.path.join(m.model_ws,'hfb6_org', m.hfb6.file_name[0]))
+    shutil.copy2(os.path.join(m.model_ws, m.hfb6.file_name[0]),
+                 os.path.join(m.model_ws,'hfb6_org', m.hfb6.file_name[0]))
 
     if not os.path.exists(os.path.join(m.model_ws, 'hfb6_mlt')):
         os.mkdir(os.path.join(m.model_ws, 'hfb6_mlt'))
@@ -2339,41 +2340,48 @@ def write_hfb_zone_multipliers_template(m):
     hfb_file_contents = open(hfb_file, 'r').readlines()
 
     # navigate the header
-    skiprows = sum([1 if i.strip().startswith('#') else 0 for i in hfb_file_contents]) + 1
+    skiprows = sum([1 if i.strip().startswith('#') else 0
+                    for i in hfb_file_contents]) + 1
     header = hfb_file_contents[:skiprows]
 
     # read in the data
     names = ['lay', 'irow1','icol1','irow2','icol2', 'hydchr']
-    hfb_in = pd.read_csv(hfb_file, skiprows=skiprows, delim_whitespace=True, names=names).dropna()
+    hfb_in = pd.read_csv(hfb_file, skiprows=skiprows,
+                         delim_whitespace=True, names=names).dropna()
     for cn in names[:-1]:
         hfb_in[cn] = hfb_in[cn].astype(np.int)
 
     # set up a multiplier for each unique conductivity value
     unique_cond = hfb_in.hydchr.unique()
-    hfb_mults = dict(zip(unique_cond, ['hbz_{0:04d}'.format(i) for i in range(len(unique_cond))]))
+    hfb_mults = dict(zip(unique_cond, ['hbz_{0:04d}'.format(i)
+                                       for i in range(len(unique_cond))]))
     # set up the TPL line for each parameter and assign
     hfb_in['tpl'] = 'blank'
     for cn, cg in hfb_in.groupby('hydchr'):
-        hfb_in.loc[hfb_in.hydchr == cn, 'tpl'] = '~{0:^10s}~'.format(hfb_mults[cn])
+        hfb_in.loc[hfb_in.hydchr == cn, 'tpl'] = '~{0:^10s}~'.format(
+            hfb_mults[cn])
 
     assert 'blank' not in hfb_in.tpl
 
     # write out the TPL file
     tpl_file = os.path.join(m.model_ws, "hfb6.mlt.tpl")
-    with open(tpl_file, 'w') as ofp:
+    with open(tpl_file, 'w', newline='') as ofp:
         ofp.write('ptf ~\n')
         [ofp.write('{0}\n'.format(line.strip())) for line in header]
         ofp.flush()
-        hfb_in[['lay', 'irow1','icol1','irow2','icol2', 'tpl']].to_csv(ofp, sep=' ', quotechar=' ',
-                header=None, index=None, mode='a')
+        hfb_in[['lay', 'irow1','icol1','irow2','icol2', 'tpl']].to_csv(
+            ofp, sep=' ', quotechar=' ', header=None, index=None, mode='a')
 
-    # make a lookup for lining up the necessary files to perform multiplication with the
-    # helpers.apply_hfb_pars() function which must be added to the forward run script
+    # make a lookup for lining up the necessary files to
+    # perform multiplication with the helpers.apply_hfb_pars() function
+    # which must be added to the forward run script
     with open(os.path.join(m.model_ws, 'hfb6_pars.csv'), 'w') as ofp:
         ofp.write('org_file,mlt_file,model_file\n')
-        ofp.write('{0},{1},{2}\n'.format(os.path.join(m.model_ws, 'hfb6_org', m.hfb6.file_name[0]),
-                                         os.path.join(m.model_ws, 'hfb6_mlt', os.path.basename(tpl_file).replace('.tpl','')),
-                                         hfb_file))
+        ofp.write('{0},{1},{2}\n'.format(
+            os.path.join(m.model_ws, 'hfb6_org', m.hfb6.file_name[0]),
+            os.path.join(m.model_ws, 'hfb6_mlt',
+                         os.path.basename(tpl_file).replace('.tpl','')),
+            hfb_file))
 
     return hfb_mults, tpl_file
 

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -2362,7 +2362,7 @@ def write_hfb_zone_multipliers_template(m):
     header = hfb_file_contents[:skiprows]
 
     # read in the data
-    names = ['lay', 'irow1','icol1','irow2','icol2', 'hydchr']
+    names = ['lay', 'irow1', 'icol1', 'irow2', 'icol2', 'hydchr']
     hfb_in = pd.read_csv(hfb_file, skiprows=skiprows,
                          delim_whitespace=True, names=names).dropna()
     for cn in names[:-1]:
@@ -2386,7 +2386,7 @@ def write_hfb_zone_multipliers_template(m):
         ofp.write('ptf ~\n')
         [ofp.write('{0}\n'.format(line.strip())) for line in header]
         ofp.flush()
-        hfb_in[['lay', 'irow1','icol1','irow2','icol2', 'tpl']].to_csv(
+        hfb_in[['lay', 'irow1', 'icol1', 'irow2', 'icol2', 'tpl']].to_csv(
             ofp, sep=' ', quotechar=' ', header=None, index=None, mode='a')
 
     # make a lookup for lining up the necessary files to
@@ -2397,7 +2397,7 @@ def write_hfb_zone_multipliers_template(m):
         ofp.write('{0},{1},{2}\n'.format(
             os.path.join(m.model_ws, 'hfb6_org', m.hfb6.file_name[0]),
             os.path.join(m.model_ws, 'hfb6_mlt',
-                         os.path.basename(tpl_file).replace('.tpl','')),
+                         os.path.basename(tpl_file).replace('.tpl', '')),
             hfb_file))
 
     return hfb_mults, tpl_file

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -3600,11 +3600,12 @@ def apply_list_pars():
                     fmts += " %9G"
         np.savetxt(os.path.join(model_ext_path, fname), df_list.loc[:, names].values, fmt=fmts)
 
-def apply_hfb_pars():
+def apply_hfb_pars(par_file='hfb6_pars.csv'):
     """ a function to apply HFB multiplier parameters.  Used to implement
     the parameterization constructed by write_hfb_zone_multipliers_template()
 
-    This is to account for the horrible HFB6 format that differs from other BCs making this a special case
+    This is to account for the horrible HFB6 format that differs from other
+    BCs making this a special case
 
     Note
     ----
@@ -3612,19 +3613,21 @@ def apply_hfb_pars():
 
     should be added to the forward_run.py script
     """
-    hfb_pars = pd.read_csv('hfb6_pars.csv')
+    hfb_pars = pd.read_csv(par_file)
 
     hfb_mults_contents = open(hfb_pars.mlt_file.values[0], 'r').readlines()
-    skiprows = sum([1 if i.strip().startswith('#') else 0 for i in hfb_mults_contents]) + 1
+    skiprows = sum([1 if i.strip().startswith('#') else 0
+                    for i in hfb_mults_contents]) + 1
     header = hfb_mults_contents[:skiprows]
 
     # read in the multipliers
     names = ['lay', 'irow1','icol1','irow2','icol2', 'hydchr']
-    hfb_mults = pd.read_csv(hfb_pars.mlt_file.values[0], skiprows=skiprows, delim_whitespace=True, names=names).dropna()
-
+    hfb_mults = pd.read_csv(hfb_pars.mlt_file.values[0], skiprows=skiprows,
+                            delim_whitespace=True, names=names).dropna()
 
     # read in the original file
-    hfb_org = pd.read_csv(hfb_pars.org_file.values[0], skiprows=skiprows, delim_whitespace=True, names=names).dropna()
+    hfb_org = pd.read_csv(hfb_pars.org_file.values[0], skiprows=skiprows,
+                          delim_whitespace=True, names=names).dropna()
 
     # multiply it out
     hfb_org.hydchr *= hfb_mults.hydchr
@@ -3633,11 +3636,12 @@ def apply_hfb_pars():
         hfb_mults[cn] = hfb_mults[cn].astype(np.int)
         hfb_org[cn] = hfb_org[cn].astype(np.int)
     # write the results
-    with open(hfb_pars.model_file.values[0], 'w') as ofp:
+    with open(hfb_pars.model_file.values[0], 'w', newline='') as ofp:
         [ofp.write('{0}\n'.format(line.strip())) for line in header]
+        ofp.flush()
+        hfb_org[['lay', 'irow1', 'icol1', 'irow2', 'icol2', 'hydchr']].to_csv(
+            ofp, sep=' ', header=None, index=None)
 
-        hfb_org[['lay', 'irow1','icol1','irow2','icol2', 'hydchr']].to_csv(ofp, sep=' ',
-                header=None, index=None)
 
 def write_const_tpl(name, tpl_file, suffix, zn_array=None, shape=None, spatial_reference=None,
                     longnames=False):


### PR DESCRIPTION
I started adding this test ages back after running into issues with my hfb template files.

Turns out my issue was related to a pandas update (0.24) where the line end interpretation had changes for windows (see https://github.com/pandas-dev/pandas/issues/25048)

So this PR also includes the (tiny) fix for that issue. When opening the file handle for writing (and eventually writing with `pandas.to_csv()`) we need to explicitly set the newline argument to `newline = ''`. Otherwise line terminators get written twice when writing out the csv. 

Hopefully this wont have any unintented consequences for those on more sensible OS.