### PR TITLE
add divide to ensemble

### DIFF
--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -102,6 +102,12 @@ class Ensemble(object):
         except:
             return self._df * other._df
 
+    def __truediv__(self, other):
+        try:
+            return self._df / other
+        except:
+            return self._df / other._df
+
     def __add__(self,other):
         try:
             return self._df + other


### PR DESCRIPTION
Maybe this was omitted from the ensemble refactor for a reason but trying to add in supporting divide function on ensemble. 

Would it be worth adding a `get_dataframe()` wrapper to the ensemble class (or a de-protected `.df`)? I might be missing something but I think that `_.df` is the only way to completely pull the dataframe object out of the ensemble class object...

thoughts?