### PR TITLE
Chunk files to speed up apply_array_pars() parallel processing

### DIFF
--- a/autotest/pst_tests_2.py
+++ b/autotest/pst_tests_2.py
@@ -660,7 +660,7 @@ def at_bounds_test():
 
 if __name__ == "__main__":
 
-    at_bounds_test()
+    # at_bounds_test()
     #process_output_files_test()
     #change_limit_test()
     #new_format_test()
@@ -675,7 +675,7 @@ if __name__ == "__main__":
     # add_obs_test()
     # add_pars_test()
     # setattr_test()
-    # run_array_pars()
+    run_array_pars()
     #from_flopy_zone_pars()
     #from_flopy_pp_test()
     #from_flopy()

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -3029,17 +3029,21 @@ def apply_array_pars(arr_par_file="arr_pars.csv"):
             p.join()
 
         print("finished fac2real",datetime.now())
-    print("starting arr mlt",datetime.now())
 
-    uniq = df.model_file.unique()
-    num_uniq = len(uniq)
-    chunk_len = 20
-    min_num_chunk = np.floor_divide(num_uniq, chunk_len)
-    main_chunks = uniq[:min_num_chunk * chunk_len].reshape([-1, chunk_len]).tolist()
-    remainder = uniq[min_num_chunk * chunk_len:].tolist()
+    print("starting arr mlt",datetime.now())
+    uniq = df.model_file.unique()  # unique model input files to be produced
+    num_uniq = len(uniq)  # number of input files to be produced
+    # number of files to send to each processor
+    chunk_len = 50  # - this may not be the optimum number,
+    # sure there is some cleverway of working it out
+    # lazy plitting the files to be processed into even chunks
+    num_chunk_floor = num_uniq // chunk_len  # number of whole chunks
+    main_chunks = uniq[:num_chunk_floor * chunk_len].reshape(
+        [-1, chunk_len]).tolist()  # the list of files broken down into chunks
+    remainder = uniq[num_chunk_floor * chunk_len:].tolist()  # remaining files
     chunks = main_chunks + [remainder]
     procs = []
-    for chunk in chunks:
+    for chunk in chunks:  # now only spawn processor for each chunk
         p = mp.Process(target=_process_chunk_model_files, args=[chunk, df])
         p.start()
         procs.append(p)


### PR DESCRIPTION
Added a little wrapper to breakdown and process `model_file`s in chunks in `apply_array_pars()`.

I think this gets greater benefit from the parallelising of the processing in `apply_array_pars()` method. Instead of spawning a processor (or thread - unsure of the correct parlance!) for every model input file,  we just break the list of files down into chunks (of 50 at the moment) and let each spawned process work on it's chunk. -- Less time spawning more time calculating (I hope). 

The effect isn't too noticeable in the test case in `pst_tests_2.py` but I have trialled it on a local problem with 840 unique model files: `apply_array_pars()` was taking over 30 minutes; now less than a minute. The efficiency saving may not be so high where more `mults` are applied per `model_file` but generally, I think it should be faster.  