### PR TITLE
 Fixing issue with `pst_path` in `pst_from_io_files()`

### DIFF
--- a/autotest/pst_tests_2.py
+++ b/autotest/pst_tests_2.py
@@ -85,7 +85,11 @@ def from_flopy():
                                          remove_existing=True,
                                          model_exe_name="mfnwt", temporal_list_props=temp_list_props,
                                          spatial_list_props=spat_list_props, hfb_pars=True)
-
+    csv = os.path.join(new_model_ws, "arr_pars.csv")
+    df = pd.read_csv(csv, index_col=0)
+    mults_not_linked_to_pst = [f for f in df.mlt_file.unique() 
+                               if f not in ph.pst.input_files]
+    assert len(mults_not_linked_to_pst) == 0, print(mults_not_linked_to_pst)
     par = ph.pst.parameter_data
     pe = ph.draw(100)
 
@@ -675,10 +679,10 @@ if __name__ == "__main__":
     # add_obs_test()
     # add_pars_test()
     # setattr_test()
-    run_array_pars()
+    # run_array_pars()
     #from_flopy_zone_pars()
     #from_flopy_pp_test()
-    #from_flopy()
+    from_flopy()
     # add_obs_test()
     #from_flopy_kl_test()
     #from_flopy_reachinput()

--- a/pyemu/pst/pst_handler.py
+++ b/pyemu/pst/pst_handler.py
@@ -2075,7 +2075,8 @@ class Pst(object):
 
 
     @classmethod
-    def from_io_files(cls,tpl_files,in_files,ins_files,out_files,pst_filename=None,pst_path='.'):
+    def from_io_files(cls, tpl_files, in_files, ins_files, out_files,
+                      pst_filename=None, pst_path=None):
         """ create a Pst instance from model interface files.
 
         Args:

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -229,7 +229,7 @@ def setup_mtlist_budget_obs(list_filename,gw_filename="mtlist_gw.dat",sw_filenam
         if df_sw is None:
             raise Exception("error processing surface water instruction file")
         df_gw = df_gw.append(df_sw)
-        df_gw.obsnme = df_gw.index.values
+        df_gw.loc[:, "obsnme"] = df_gw.index.values
     if save_setup_file:
         df_gw.to_csv("_setup_" + os.path.split(list_filename)[-1] + '.csv', index=False)
 
@@ -325,7 +325,7 @@ def setup_mflist_budget_obs(list_filename,flx_filename="flux.dat",
 
         It is recommended to use the default values for flux_file and vol_file.
 
-        This is the companion function of `gw_utils.setup_mflist_budget_obs()`.
+        This is the companion function of `gw_utils.apply_mflist_budget_obs()`.
 
 
     """

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -928,8 +928,8 @@ def parse_dir_for_io_files(d):
     return tpl_files,in_files,ins_files,out_files
 
 
-def pst_from_io_files(tpl_files,in_files,ins_files,out_files,pst_filename=None,
-                      pst_path='.'):
+def pst_from_io_files(tpl_files, in_files, ins_files, out_files,
+                      pst_filename=None, pst_path=None):
     """ create a Pst instance from model interface files.
 
     Args:
@@ -1005,17 +1005,24 @@ def pst_from_io_files(tpl_files,in_files,ins_files,out_files,pst_filename=None,
     if "window" in platform.platform().lower() and pst_path == ".":
         pst_path = ''
 
-    new_pst.template_files = [os.path.join(pst_path,os.path.split(tpl_file)[-1]) for tpl_file in tpl_files]
-    new_pst.input_files = [os.path.join(pst_path,os.path.split(in_file)[-1]) for in_file in in_files]
     new_pst.instruction_files = ins_files
     new_pst.output_files = out_files
 
     #try to run inschek to find the observtion values
     pyemu.pst_utils.try_process_output_pst(new_pst)
-
-    # now set the true path location to instruction files and output files
-    new_pst.instruction_files = [os.path.join(pst_path, os.path.split(ins_file)[-1]) for ins_file in ins_files]
-    new_pst.output_files = [os.path.join(pst_path, os.path.split(out_file)[-1]) for out_file in out_files]
+    if pst_path is None:
+        new_pst.template_files = tpl_files
+        new_pst.input_files = in_files
+    else:
+        new_pst.template_files = [os.path.join(
+            pst_path, os.path.split(tpl_file)[-1]) for tpl_file in tpl_files]
+        new_pst.input_files = [os.path.join(
+            pst_path, os.path.split(in_file)[-1]) for in_file in in_files]
+        # now set the true path location to instruction files and output files
+        new_pst.instruction_files = [os.path.join(
+            pst_path, os.path.split(ins_file)[-1]) for ins_file in ins_files]
+        new_pst.output_files = [os.path.join(
+            pst_path, os.path.split(out_file)[-1]) for out_file in out_files]
 
     if pst_filename:
         new_pst.write(pst_filename,update_regul=True)


### PR DESCRIPTION
The new support for specifying `pst_path` breaks pest/pyemu where apply_array_pars() (and similar) are expecting mult files to be in subdirectories (which is the result of the `_setup_..._pars()` functions), as it strips the file basename from the path. As a result the input files that PEST generates are created in the wrong directory and are then not available for the `apply_array_pars()` functions. 

I guess this slipped through the tests because there are still (dummy) mult files in the mult directories - but these wont get updated by PEST!

This PR seems to fix this issue but I am not totally across the aim/logic for the addition of the `pst_path` option so there is a chance that I might have broken how this works. - not sure what the "catch all" option is for this.