### PR TITLE
Adding chunking method to `write_input_files()` method

### DIFF
--- a/autotest/pst_tests.py
+++ b/autotest/pst_tests.py
@@ -751,7 +751,7 @@ def process_output_files_test():
 
 
 if __name__ == "__main__":
-    process_output_files_test()
+    # process_output_files_test()
     #change_limit_test()
     #new_format_test()
     #lt_gt_constraint_names_test()
@@ -761,7 +761,7 @@ if __name__ == "__main__":
     #try_process_ins_test()
     # write_tables_test()
     #res_stats_test()
-    #test_write_input_files()
+    test_write_input_files()
     # add_obs_test()
     # add_pars_test()
     # setattr_test()

--- a/pyemu/pst/pst_utils.py
+++ b/pyemu/pst/pst_utils.py
@@ -333,7 +333,7 @@ def write_input_files(pst,pst_path='.'):
         #write_to_template(pst.parameter_data.parval1_trans,os.path.join(pst_path,tpl_file),
         #                  os.path.join(pst_path,in_file))
         p = mp.Process(target=_write_chunk_to_template,
-                       args=[chunk, pst.parameter_data.parval1_trans, 
+                       args=[chunk, pst.parameter_data.parval1_trans,
                              pst_path])
         p.start()
         procs.append(p)


### PR DESCRIPTION
Adding chunking method to speed up multiprocessing in `write_input_files()` method a la PR #97.

Again seems to provide a bit of a speed up as fewer threads are spawned (i.e. 1 per 50 files rather than 1 per file).