### PR TITLE
Chasing pandas 2.0 issues

### DIFF
--- a/autotest/en_tests.py
+++ b/autotest/en_tests.py
@@ -263,6 +263,11 @@ def enforce_test():
     pe.enforce(how="drop")
     assert pe.shape[0] == num_reals - 1
 
+    pe = pyemu.ParameterEnsemble.from_gaussian_draw(pst, num_reals=num_reals)
+    pe.transform()
+    pe.enforce()
+
+
 def pnulpar_test(tmp_path):
     import os
     import pyemu

--- a/autotest/plot_tests.py
+++ b/autotest/plot_tests.py
@@ -60,6 +60,7 @@ def pst_plot_test(tmp_path):
     os.chdir(tmp_path)
     try:
         pst = pyemu.Pst("pest.pst")
+        pst.plot()
         pst.parameter_data.loc[:, "partrans"] = "none"
         pst.plot()
 
@@ -163,7 +164,7 @@ def ensemble_plot_test(tmp_path):
                                          plot_cols=pst.par_names[:10], sync_bins=False,
                                          func_dict={pst.par_names[0]:np.log10})
         plt.close("all")
-        deter_vals = pst.parameter_data.parval1.apply(lambda x: np.log10(x)).to_dict()
+        deter_vals = pst.parameter_data.parval1.apply(np.log10).to_dict()
         pyemu.plot_utils.ensemble_helper({"b": pe, "y": csv_file}, filename=csv_file + ".pdf",
                                          plot_cols=pst.par_names[:10], sync_bins=False,
                                          deter_vals=deter_vals)
@@ -253,11 +254,11 @@ def ensemble_1to1_test(tmp_path):
         base_ensemble=oe_base2
     )
 
-    # pyemu.plot_utils.ensemble_res_1to1(
-    #     {"0.5": oe1+1, "b": oe2},
-    #     pst,
-    #     filename="e1to1_noise6.pdf"
-    # )
+    pyemu.plot_utils.ensemble_res_1to1(
+        {"0.5": oe1+1, "b": oe2},
+        pst,
+        filename="e1to1_noise6.pdf"
+    )
 
     pst.observation_data.loc[:, 'obgnme'] = pst.observation_data.o_obgnme
     pyemu.plot_utils.res_phi_pie(pst=pst,ensemble=oe1)

--- a/autotest/utils_tests.py
+++ b/autotest/utils_tests.py
@@ -1337,8 +1337,8 @@ def sfr_helper_test(tmp_path):  # TODO: need attention to move IO to tmp_path (p
         m1 = flopy.modflow.Modflow.load("supply2.nam", load_only=["sfr"], check=False)
         for kper,sd in m1.sfr.segment_data.items():
             #print(sd["flow"],sd1[kper]["flow"])
-            for i1,i2 in zip(sd["flow"],sd1[kper]["flow"]):
-                assert i1 * 10 == i2,"{0},{1}".format(i1,i2)
+            for i1, i2 in zip(sd["flow"], sd1[kper]["flow"]):
+                assert i1 * 10 == i2, "{0},{1}".format(i1, i2)
 
         df_sfr = pyemu.gw_utils.setup_sfr_seg_parameters("supply2.nam", model_ws=m_ws, include_temporal_pars=True)
 

--- a/pyemu/__init__.py
+++ b/pyemu/__init__.py
@@ -31,7 +31,13 @@ from .plot import plot_utils
 from .logger import Logger
 
 #from .prototypes import *
-from .legacy import *
+try:
+    from .legacy import *
+except (ModuleNotFoundError, ImportError) as e:
+    import warnings
+    warnings.warn("Failed to import legacy module. "
+                  "May impact ability to access older methods."
+                  f"{type(e).__name__} {e.msg}")
 
 from ._version import get_versions
 

--- a/pyemu/en.py
+++ b/pyemu/en.py
@@ -935,7 +935,7 @@ class ParameterEnsemble(Ensemble):
         par = pst.parameter_data
         li = par.partrans == "log"
         mean_values = par.parval1.copy()
-        mean_values.loc[li] = [np.log10(v) for v in mean_values.loc[li].values]
+        mean_values.loc[li] = mean_values.loc[li].apply(np.log10)
         if len(pst.adj_par_names) == 0:
             warnings.warn("ParameterEnsemble.from_gaussian_draw(): no adj pars", PyemuWarning)
         grouper = None
@@ -986,13 +986,13 @@ class ParameterEnsemble(Ensemble):
 
         li = pst.parameter_data.partrans == "log"
         ub = pst.parameter_data.parubnd.copy()
-        ub.loc[li] = [np.log10(v) for v in ub.loc[li].values]
+        ub.loc[li] = ub.loc[li].apply(np.log10)
 
         lb = pst.parameter_data.parlbnd.copy()
-        lb.loc[li] = [np.log10(v) for v in lb.loc[li].values]
+        lb.loc[li] = lb.loc[li].apply(np.log10)
 
         pv = pst.parameter_data.parval1.copy()
-        pv.loc[li] = [np.log10(v) for v in pv[li].values]
+        pv.loc[li] = pv[li].apply(np.log10)
 
         ub = ub.to_dict()
         lb = lb.to_dict()
@@ -1055,10 +1055,10 @@ class ParameterEnsemble(Ensemble):
 
         li = pst.parameter_data.partrans == "log"
         ub = pst.parameter_data.parubnd.copy()
-        ub.loc[li] = [np.log10(v) for v in ub.loc[li].values]
+        ub.loc[li] = ub.loc[li].apply(np.log10)
         ub = ub.to_dict()
         lb = pst.parameter_data.parlbnd.copy()
-        lb.loc[li] = [np.log10(v) for v in lb.loc[li].values]
+        lb.loc[li] = lb.loc[li].apply(np.log10)
         lb = lb.to_dict()
 
         real_names = np.arange(num_reals, dtype=np.int64)
@@ -1175,7 +1175,7 @@ class ParameterEnsemble(Ensemble):
         # gaussian
         pes = []
         if len(how_groups["gaussian"]) > 0:
-            gset = list(set(how_groups["gaussian"]))
+            gset = how_groups["gaussian"]
             par_gaussian = par_org.loc[gset, :]
             # par_gaussian.sort_values(by="parnme", inplace=True)
             par_gaussian.sort_index(inplace=True)
@@ -1184,7 +1184,7 @@ class ParameterEnsemble(Ensemble):
             if cov is not None:
                 cset = set(cov.row_names)
                 # gset = set(how_groups["gaussian"])
-                diff = gset.difference(cset)
+                diff = set(gset).difference(cset)
                 assert len(diff) == 0, (
                     "ParameterEnsemble.from_mixed_draws() error: the 'cov' is not compatible with "
                     + " the parameters listed as 'gaussian' in how_dict, the following are not in the cov:{0}".format(
@@ -1272,8 +1272,7 @@ class ParameterEnsemble(Ensemble):
             # check for scale differences - I don't who is dumb enough
             # to change scale between par files and pst...
             diff = df.scale - pst.parameter_data.scale
-            dsum = sum([np.abs(v) for v in diff.values])
-            if dsum > 0.0:
+            if diff.abs().sum() > 0.0:
                 warnings.warn(
                     "differences in scale detected, applying scale in par file",
                     PyemuWarning,
@@ -1349,7 +1348,7 @@ class ParameterEnsemble(Ensemble):
         df = self._df
         # self.loc[:,:] = (self.loc[:,:] * self.pst.parameter_data.scale) +\
         #                 self.pst.parameter_data.offset
-        df.loc[:, li] = [np.log10(v) for v in df.loc[:, li].values]
+        df.loc[:, li] = df.loc[:, li].apply(np.log10)
         self._istransformed = True
 
     def add_base(self):
@@ -1396,7 +1395,7 @@ class ParameterEnsemble(Ensemble):
             return self.pst.parameter_data.parubnd.copy()
         else:
             ub = self.pst.parameter_data.parubnd.copy()
-            ub[self.log_indexer] = [np.log10(v) for v in ub[self.log_indexer]]
+            ub[self.log_indexer] = np.log10(ub[self.log_indexer])
             return ub
 
     @property
@@ -1412,7 +1411,7 @@ class ParameterEnsemble(Ensemble):
             return self.pst.parameter_data.parlbnd.copy()
         else:
             lb = self.pst.parameter_data.parlbnd.copy()
-            lb[self.log_indexer] = [np.log10(v) for v in lb[self.log_indexer]]
+            lb[self.log_indexer] = np.log10(lb[self.log_indexer])
             return lb
 
     @property
@@ -1546,7 +1545,7 @@ class ParameterEnsemble(Ensemble):
         else:
             raise Exception(
                 "unrecognized enforce_bounds arg:"
-                + "{0}, should be 'reset' or 'drop'".format(enforce_bounds)
+                + "{0}, should be 'reset' or 'drop'".format(how)
             )
 
     def _enforce_scale(self, bound_tol):
@@ -1557,8 +1556,8 @@ class ParameterEnsemble(Ensemble):
         ub = self.ubnd * (1.0 - bound_tol)
         lb = self.lbnd * (1.0 + bound_tol)
         base_vals = self.pst.parameter_data.loc[self._df.columns, "parval1"].copy()
-        ub_dist = pd.Series(data=np.abs((ub - base_vals).values),index=base_vals.index,dtype=float)
-        lb_dist = pd.Series(data=np.abs((base_vals - lb).values),index=base_vals.index,dtype=float)
+        ub_dist = (ub - base_vals).apply(np.abs)
+        lb_dist = (base_vals - lb).apply(np.abs)
 
         if ub_dist.min() <= 0.0:
             raise Exception(
@@ -1576,8 +1575,7 @@ class ParameterEnsemble(Ensemble):
             )
         for ridx in self._df.index:
             real = self._df.loc[ridx, :]
-            real_dist = pd.Series(data=np.abs((real - base_vals).values),index=real.index,dtype=float)
-
+            real_dist = (real - base_vals).apply(np.abs)
             out_ubnd = real - ub
             out_ubnd = out_ubnd.loc[out_ubnd > 0.0]
             ubnd_facs = ub_dist.loc[out_ubnd.index] / real_dist.loc[out_ubnd.index]
@@ -1606,7 +1604,7 @@ class ParameterEnsemble(Ensemble):
 
             if lbnd_facs.shape[0] > 0:
                 lmin = lbnd_facs.min()
-                print(lbnd_facs)
+                # print(lbnd_facs)
                 lmin_idx = lbnd_facs.idxmin()
                 print(
                     "enforce_scale lbnd controlling parameter, scale factor, "

--- a/pyemu/utils/geostats.py
+++ b/pyemu/utils/geostats.py
@@ -788,10 +788,10 @@ class OrdinaryKrige(object):
             warnings.warn(
                 "duplicates detected in point_data..attempting to rectify", PyemuWarning
             )
-            ux_std = point_data.loc[:,["x"]].groupby(point_data.name).std()["x"]
+            ux_std = point_data.groupby(point_data.name).x.std()
             if ux_std.max() > 0.0:
                 raise Exception("duplicate point_info entries with different x values")
-            uy_std = point_data.loc[:,["y"]].groupby(point_data.name).std()["y"]
+            uy_std = point_data.groupby(point_data.name).y.std()
             if uy_std.max() > 0.0:
                 raise Exception("duplicate point_info entries with different y values")
 
@@ -1291,14 +1291,14 @@ class OrdinaryKrige(object):
                 continue
 
             # only the maxpts_interp points
-            pt_names = dist.iloc[:maxpts_interp].index.values
-            dist = np.sqrt(dist.iloc[:maxpts_interp].values)
+            pt_names = dist.index.values[:maxpts_interp]
+            dist = np.sqrt(dist.values[:maxpts_interp])
             
             # if one of the points is super close, just use it and skip
             if dist.min() <= EPSILON:
                 ifacts.append([1.0])
                 idist.append([EPSILON])
-                inames.append([pt_names[np.argmin(dist)]])
+                inames.append([pt_names[dist.argmin()]])
                 err_var.append(self.geostruct.nugget)
                 continue
             # if verbose == 2:

--- a/pyemu/utils/gw_utils.py
+++ b/pyemu/utils/gw_utils.py
@@ -1315,17 +1315,16 @@ def setup_sft_obs(sft_file, ins_file=None, start_datetime=None, times=None, ncom
     idx = df.time.apply(lambda x: x in times)
     if start_datetime is not None:
         start_datetime = pd.to_datetime(start_datetime)
-        df.loc[:, "dt"] = pd.to_timedelta(df.time, unit="d") + start_datetime
-        df.loc[:, "time_str"] = df.dt.dt.strftime("%Y%m%d").values
-        print(df.time_str)
-        
+        df["time_str"] = pd.to_timedelta(df.time, unit="d") + start_datetime
+        df["time_str"] = df.time_str.dt.strftime("%Y%m%d")
+        # print(df.time_str)
     else:
-        df.loc[:, "time_str"] = df.time.apply(lambda x: "{0:08.2f}".format(x))
-    df.loc[:, "ins_str"] = "l1\n"
+        df["time_str"] = df.time.apply(lambda x: f"{x:08.2f}")
+    df["ins_str"] = "l1\n"
     # check for multiple components
-    df_times = df.loc[idx, :]
+    # df_times = df.loc[idx, :]
     df.loc[:, "icomp"] = 1
-    icomp_idx = list(df.columns).index("icomp")
+    # icomp_idx = list(df.columns).index("icomp")
     for t in times:
         df_time = df.loc[df.time == t, :].copy()
         vc = df_time.sfr_node.value_counts()
@@ -2558,12 +2557,12 @@ def setup_gage_obs(gage_file, ins_file=None, start_datetime=None, times=None):
     if start_datetime is not None:
         # convert times to usable observation times
         start_datetime = pd.to_datetime(start_datetime)
-        df.loc[:, "dt"] = pd.to_timedelta(df.time, unit="d") + start_datetime
-        df.loc[:, "time_str"] = df.dt.dt.strftime("%Y%m%d")
+        df["time_str"] = pd.to_timedelta(df.time, unit="d") + start_datetime
+        df["time_str"] = df.time_str.dt.strftime("%Y%m%d")
     else:
-        df.loc[:, "time_str"] = df.time.apply(lambda x: "{0:08.2f}".format(x))
+        df["time_str"] = df.time.apply(lambda x: f"{x:08.2f}")
     # set up instructions (line feed for lines without obs (not in time)
-    df.loc[:, "ins_str"] = "l1\n"
+    df["ins_str"] = "l1\n"
     df_times = df.loc[idx, :]  # Slice by desired times
     # TODO include GAGE No. in obs name (if permissible)
     df.loc[df_times.index, "ins_str"] = df_times.apply(

--- a/pyemu/utils/helpers.py
+++ b/pyemu/utils/helpers.py
@@ -999,7 +999,7 @@ def zero_order_tikhonov(pst, parbounds=True, par_groups=None, reset=True):
             {"pilbl": pilbl, "equation": equation, "obgnme": obgnme, "weight": weight}
         )
 
-        pst.prior_information = pd.concat([pst.prior_information,pi])
+        pst.prior_information = pd.concat([pst.prior_information, pi])
     if parbounds:
         _regweight_from_parbound(pst)
     if pst.control_data.pestmode == "estimation":
@@ -1104,7 +1104,7 @@ def first_order_pearson_tikhonov(pst, cov, reset=True, abs_drop_tol=1.0e-3):
     if reset:
         pst.prior_information = df
     else:
-        pst.prior_information = pd.concat([pst.prior_information,df])
+        pst.prior_information = pd.concat([pst.prior_information, df])
 
     if pst.control_data.pestmode == "estimation":
         pst.control_data.pestmode = "regularization"
@@ -1339,11 +1339,11 @@ def jco_from_pestpp_runstorage(rnj_filename, pst_filename):
         raise Exception("couldn't get base run...")
     par = par.loc[base_par.index, :]
     li = base_par.index.map(lambda x: par.loc[x, "partrans"] == "log")
-    base_par.loc[li] = [np.log10(v) for v in base_par.loc[li].values]
+    base_par.loc[li] = base_par.loc[li].apply(np.log10)
     jco_cols = {}
     for irun in range(1, int(header["n_runs"])):
         par_df, obs_df = read_pestpp_runstorage(rnj_filename, irun=irun)
-        par_df.loc[li] = [np.log10(v) for v in par_df.loc[li].values]
+        par_df.loc[li] = par_df.loc[li].apply(np.log10)
         obs_diff = base_obs - obs_df
         par_diff = base_par - par_df
         # check only one non-zero element per col(par)
@@ -2243,13 +2243,13 @@ def build_jac_test_csv(pst, num_steps, par_names=None, forward=True):
     li = par.partrans == "log"
     lbnd = par.parlbnd.copy()
     ubnd = par.parubnd.copy()
-    lbnd.loc[li] = [np.log10(v) for v in lbnd.loc[li].values]
-    ubnd.loc[li] = [np.log10(v) for v in ubnd.loc[li].values]
+    lbnd.loc[li] = lbnd.loc[li].apply(np.log10)
+    ubnd.loc[li] = ubnd.loc[li].apply(np.log10)
     lbnd = lbnd.to_dict()
     ubnd = ubnd.to_dict()
 
     org_vals = par.parval1.copy()
-    org_vals.loc[li] = [np.log10(v) for v in org_vals.loc[li].values]
+    org_vals.loc[li] = org_vals.loc[li].apply(np.log10)
     if forward:
         sign = 1.0
     else:


### PR DESCRIPTION
Looks like issues are less related to the use of ufunc (e.g. np.log10) on Object type series (which has be deprecated since before Pandas 1.5) but rather related to assignments with `df.loc[:,col] = RHS` casting RHS into the dtype of `df[col]` and, therefore, when RHS is expected to update the series dtype (e.g. to float or int [using apply() or astype()]) the action does nothing. Conversion of pst data cols was not occuring as expected and subsequent ufunc calls (e.g. log10) were failing. A big WTF but seems to work if the assignment is of the form `df[col]=RHS`.

Have stripped back most of JTW mods after making this change in pst_handler.py