### PR TITLE
hotfix illegal file name characters

### DIFF
--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -4042,7 +4042,11 @@ def prep_pp_hyperpars(file_tag,pp_filename,pp_info,out_filename,grid_dict,
     except Exception as e:
         raise Exception("prep_pp_hyperpars() error importing pypestutils: '{0}'".format(str(e)))
 
-
+    illegal_chars = [i for i in r"/:*?<>\|"]
+    for i in illegal_chars:
+        print("warning: replacing illegal character '{0}' with '-' in file_tag name '{1}'".format(i,pg))
+        file_tag = file_tag.replace(i,"-")
+        
     gridinfo_filename = file_tag + ".gridinfo.dat"
     corrlen_filename = file_tag + ".corrlen.dat"
     bearing_filename = file_tag + ".bearing.dat"

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -4044,9 +4044,9 @@ def prep_pp_hyperpars(file_tag,pp_filename,pp_info,out_filename,grid_dict,
 
     illegal_chars = [i for i in r"/:*?<>\|"]
     for i in illegal_chars:
-        print("warning: replacing illegal character '{0}' with '-' in file_tag name '{1}'".format(i,pg))
+        print("warning: replacing illegal character '{0}' with '-' in file_tag name '{1}'".format(i,file_tag))
         file_tag = file_tag.replace(i,"-")
-        
+
     gridinfo_filename = file_tag + ".gridinfo.dat"
     corrlen_filename = file_tag + ".corrlen.dat"
     bearing_filename = file_tag + ".bearing.dat"

--- a/pyemu/utils/pst_from.py
+++ b/pyemu/utils/pst_from.py
@@ -4044,8 +4044,9 @@ def prep_pp_hyperpars(file_tag,pp_filename,pp_info,out_filename,grid_dict,
 
     illegal_chars = [i for i in r"/:*?<>\|"]
     for i in illegal_chars:
-        print("warning: replacing illegal character '{0}' with '-' in file_tag name '{1}'".format(i,file_tag))
-        file_tag = file_tag.replace(i,"-")
+        if i in file_tag:
+            print("warning: replacing illegal character '{0}' with '-' in file_tag name '{1}'".format(i,file_tag))
+            file_tag = file_tag.replace(i,"-")
 
     gridinfo_filename = file_tag + ".gridinfo.dat"
     corrlen_filename = file_tag + ".corrlen.dat"


### PR DESCRIPTION
pargp names are used as tags in prep_pp_hyperpars() to create file names. The use of ":" in pargp names in the tests causes windoze to fail with no warning.

Consider some more careful handling or checks of fnames? This is a rough fix